### PR TITLE
Add Content-Type header when sending JSON to /api/v2/spans

### DIFF
--- a/src/Monitor/Tracing/Zipkin.hs
+++ b/src/Monitor/Tracing/Zipkin.hs
@@ -130,6 +130,7 @@ new (Settings mbHostname mbPort mbEpt mbMgr mbPrd) = liftIO $ do
     req = HTTP.defaultRequest
       { HTTP.method = "POST"
       , HTTP.host = BS.pack (fromMaybe "localhost" mbHostname)
+      , HTTP.requestHeaders = [("Content-Type", "application/json")]
       , HTTP.path = "/api/v2/spans"
       , HTTP.port = maybe 9411 fromIntegral mbPort }
   void $ let prd = fromMaybe 0 mbPrd in if prd <= 0


### PR DESCRIPTION
Without the Content-Type Jaeger (tested using version 1.18) responded with "Unsupported Content-Type":

    > curl -XPOST -d @foo2.json http://localhost:9411/api/v2/spans
    Unsupported Content-Type