### PR TITLE
Derive more

### DIFF
--- a/src/Control/Monad/Trace.hs
+++ b/src/Control/Monad/Trace.hs
@@ -29,10 +29,15 @@ import Control.Monad.Trace.Class
 import Control.Monad.Trace.Internal
 
 import Control.Applicative ((<|>))
+import Control.Monad.Base (MonadBase)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Reader (ReaderT(ReaderT), ask, asks, local, runReaderT)
 import Control.Monad.Reader.Class (MonadReader)
+import Control.Monad.Error.Class (MonadError)
+import Control.Monad.State.Class (MonadState)
 import Control.Monad.Trans.Class (MonadTrans, lift)
+import Control.Monad.Trans.Control (MonadBaseControl)
+import Control.Monad.Writer.Class (MonadWriter)
 import qualified Data.Aeson as JSON
 import Data.Foldable (for_)
 import Data.List (sortOn)
@@ -102,7 +107,9 @@ data Scope = Scope
 
 -- | A span generation monad.
 newtype TraceT m a = TraceT { traceTReader :: ReaderT Scope m a }
-  deriving (Functor, Applicative, Monad, MonadIO, MonadTrans)
+  deriving ( Functor, Applicative, Monad, MonadTrans
+           , MonadWriter w, MonadState s, MonadError e
+           , MonadIO, MonadBase b, MonadBaseControl b )
 
 instance MonadReader r m => MonadReader r (TraceT m) where
   ask = lift ask

--- a/tracing.cabal
+++ b/tracing.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name: tracing
-version: 0.0.5.1
+version: 0.0.5.2
 synopsis: Distributed tracing
 description:
   An OpenTracing-compliant, simple, and extensible distributed tracing library.
@@ -39,6 +39,7 @@ library
     , case-insensitive >= 1.2
     , containers >= 0.6
     , http-client >= 0.5
+    , monad-control >= 1.0
     , mtl >= 2.2
     , network >= 2.8
     , random >= 1.1
@@ -46,6 +47,7 @@ library
     , text >= 1.2
     , time >= 1.8
     , transformers >= 0.5
+    , transformers-base >= 0.4
     , unliftio >= 0.2
   ghc-options: -Wall
   default-language: Haskell2010


### PR DESCRIPTION
This PR adds more auto-derivable classes to `TraceT`. These have proved to be useful when using `tracing` as part of the [Mu](https://github.com/higherkindness/mu-haskell/pull/206) microservice library.