### PR TITLE
consumerSpan should use B3 as parent reference.

### DIFF
--- a/src/Monitor/Tracing/Zipkin.hs
+++ b/src/Monitor/Tracing/Zipkin.hs
@@ -358,16 +358,16 @@ incomingSpan kind endo actn =
 serverSpan :: MonadTrace m => B3 -> m a -> m a
 serverSpan = serverSpanWith id
 
--- | Generates a child span with @SERVER@ kind, optionally modifying the span's builder. This can be useful in
--- combination with 'addEndpoint' if the remote client does not have tracing enabled.
--- The clients's 'B3' should be provided as input.
--- Client and server annotations go on the same span - it means that they share their span ID.
+-- | Generates a child span with @SERVER@ kind, optionally modifying the span's builder. This can
+-- be useful in combination with 'addEndpoint' if the remote client does not have tracing enabled.
+-- The clients's 'B3' should be provided as input. Client and server annotations go on the same
+-- span - it means that they share their span ID.
 serverSpanWith :: MonadTrace m => (Builder -> Builder) -> B3 -> m a -> m a
 serverSpanWith f b3 = incomingSpan "SERVER" (importB3 b3 <> Endo (\bldr -> f $ bldr { builderSpanID = Just (b3SpanID b3) }))
 
--- | Generates a child span with @CONSUMER@ kind, optionally modifying the span's builder.
--- The producer's 'B3' should be provided as input.
--- The generated span will have its parent ID set to the input B3's span ID.
+-- | Generates a child span with @CONSUMER@ kind, optionally modifying the span's builder. The
+-- producer's 'B3' should be provided as input. The generated span will have its parent ID set to
+-- the input B3's span ID.
 consumerSpanWith :: MonadTrace m => (Builder -> Builder) -> B3 -> m a -> m a
 consumerSpanWith f b3 = incomingSpan "CONSUMER" (importB3 b3 <> Endo (\bldr -> f $ bldr { builderReferences = Set.singleton (ChildOf $ b3SpanID b3) }))
 

--- a/tracing.cabal
+++ b/tracing.cabal
@@ -44,7 +44,7 @@ library
     , random >= 1.1
     , stm >= 2.5
     , text >= 1.2
-    , time >= 1.8
+    , time >= 1.8 && < 1.10
     , transformers >= 0.5
     , unliftio >= 0.2
   ghc-options: -Wall


### PR DESCRIPTION
Should resolve https://github.com/mtth/tracing/issues/6. I hope you like the style/refactoring, If not don't hesitate to propose improvements/changes - or just change it 😉 

Maybe more convenience methods should be added - e.g. to name a consumer you have to write code like `ZPK.consumerSpanWith (\bldr -> bldr { TC.builderName = "consumer" })`. But one step at a time.