### PR TITLE
Add support for 16 hex character traceIds.

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -71,6 +71,12 @@ main = hspec $ do
         mbBs = ZPK.b3ToHeaderValue <$> ZPK.b3FromHeaderValue bs
       mbBs `shouldBe` Just bs
 
+    it "should round-trip a B3 using a single header with a 16 lower-hex character TraceId" $ do
+      let
+        bs = "64fe8b2a57d3eff7-e457b5a2e4d86bd1-1-05e3ac9a4f6e3b90"
+        mbBs = ZPK.b3ToHeaderValue <$> ZPK.b3FromHeaderValue bs
+      mbBs `shouldBe` Just bs
+
     it "should have equivalent B3 header representations" $ do
       let
         bs = "80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-1-05e3ac9a4f6e3b90"


### PR DESCRIPTION
Resolves https://github.com/mtth/tracing/issues/12

Intentionally I only changed Zipkin.hs and not Trace/Internal.hs:
a) It's part of the Zipkin specification, so I thought it naturally belongs to Zipkin.hs 😄 
b) Other propagation standards (e.g. https://www.w3.org/TR/trace-context/#trace-id) use 128-bit - so I believe it's okay to always use 128-bit internally
c) Even if this is a internal module - it's public API - so to only change things in Zipkin.hs reduces the chance of a breaking change

But it has the drawback that the handling is somehow distributed and the implementation looks "patched".

As always, just let me know what you think.