### PR TITLE
Updated tracing.cabal to unblock stackage nightly.

### DIFF
--- a/tracing.cabal
+++ b/tracing.cabal
@@ -44,7 +44,7 @@ library
     , random >= 1.1
     , stm >= 2.5
     , text >= 1.2
-    , time >= 1.8 && < 1.10
+    , time >= 1.8
     , transformers >= 0.5
     , unliftio >= 0.2
   ghc-options: -Wall


### PR DESCRIPTION
Upper limit was once necessary to support ghc 8.0 (https://travis-ci.org/github/mtth/tracing/builds/764494212) - but now seems to block stackage nightly. Not really sure what ghc versions should be supported - travis-ci build is outdated; and github action is using ghc 8.6.5. However this is another story.