### PR TITLE
Bugfixs: Do not prefix kind keys in `addConsumerKind` and `addProducerKind`.

### DIFF
--- a/src/Monitor/Tracing/Zipkin.hs
+++ b/src/Monitor/Tracing/Zipkin.hs
@@ -183,7 +183,7 @@ addTag key val bldr =
 -- Use this method if you want to create a root consumer span. Otherwise use 'consumerSpanWith' to
 -- create a sub span with consumer kind.
 addConsumerKind :: Builder -> Builder
-addConsumerKind = addTag kindKey consumerKindValue
+addConsumerKind = appEndo $ insertTag kindKey consumerKindValue
 
 -- | Adds a producer kind tag to a builder. This is a convenience method to use with 'rootSpanWith',
 -- for example:
@@ -193,7 +193,7 @@ addConsumerKind = addTag kindKey consumerKindValue
 -- Use this method if you want to create a root producer span. Otherwise use 'producerSpanWith' to
 -- create a sub span with producer kind.
 addProducerKind :: Builder -> Builder
-addProducerKind = addTag kindKey producerKindValue
+addProducerKind = appEndo $ insertTag kindKey producerKindValue
 
 -- | Adds an inherited tag to a builder. Unlike a tag added via 'addTag', this tag:
 --


### PR DESCRIPTION
Sorry,  but I've introduced a small bug with #15 and #25. The kindKey gets prefixed and therefore the kind of the span is transmitted as a custom attribute - and not as the kind attribute of the span.